### PR TITLE
single rng instance called from everywhere

### DIFF
--- a/config_files/spec_example.yaml
+++ b/config_files/spec_example.yaml
@@ -53,10 +53,6 @@ Daq:
     roach_inverted_flag: True # this effectively deletes every other file when roach_avg=2
     requant_gain: 17 
     noise_file_gain: 17 #requant gain that the noise profile was taken with
-    rng_seed: 123456
     build_labels: False
     gain_noise_csv_path: "C:/Users/RJ/OneDrive - North Carolina State University/Research/CRES/he6-cres-spec-sims/config_files/base_gain_noise.csv"
     spec_prefix: "SNR_dev"
-
-SpecBuilder:
-    specfile_name: "SNR_dev_spec_file"

--- a/src/he6_cres_spec_sims/experiment.py
+++ b/src/he6_cres_spec_sims/experiment.py
@@ -120,7 +120,11 @@ class Experiment:
                 config_dict = yaml.load(f, Loader=yaml.FullLoader)
 
             # Make the appropriate altercations to the config_dict
-            config_dict["Settings"]["rand_seed"] = int(seed)
+            # For seed = None, rng pulls from hardware entropy
+            if seed is not None:
+                config_dict["Settings"]["rand_seed"] = int(seed)
+            else:
+                config_dict["Settings"]["rand_seed"] = None
             config_dict["Physics"]["events_to_simulate"] = int(events_to_simulate)
             config_dict["Physics"]["betas_to_simulate"] = int(betas_to_simulate)
             config_dict["Physics"]["energy_spectrum"]["beta_source"] = str(isotope)

--- a/src/he6_cres_spec_sims/simulation_blocks/DAQ.py
+++ b/src/he6_cres_spec_sims/simulation_blocks/DAQ.py
@@ -44,8 +44,6 @@ class DAQ:
             self.gain_noise.freq, self.gain_noise.gain
         )
 
-        self.rng = np.random.default_rng(self.config.daq.rand_seed)
-
         self.noise_array = self.build_noise_floor_array()
 
     def run(self, downmixed_tracks_df):
@@ -58,8 +56,8 @@ class DAQ:
         self.build_spec_file_paths()
         self.build_empty_spec_files()
 
-        # Define a random phase for each band.
-        self.phase = self.rng.random(size=len(self.tracks))
+        # Define a random phase for each band (multiplied by 2 pi at use).
+        self.phase = self.config.rng.uniform(size=len(self.tracks))
 
         if self.config.daq.build_labels:
             self.build_label_file_paths()
@@ -80,7 +78,7 @@ class DAQ:
                 num_slices = (stop_slice - start_slice) * self.config.daq.roach_avg
 
                 noise_array = self.noise_array.copy()
-                self.rng.shuffle(noise_array)
+                self.config.rng.shuffle(noise_array)
                 noise_array = noise_array[: num_slices]
 
                 signal_array = self.build_signal_chunk(
@@ -309,7 +307,7 @@ class DAQ:
         noise_scaling = noise_power_scaling * requant_gain_scaling
 
         # Chisquared noise:
-        noise_array = self.rng.chisquare(
+        noise_array = self.config.rng.chisquare(
             df=2, size=(self.slice_block * self.config.daq.roach_avg, self.config.daq.freq_bins)
         )
         noise_array *= self.noise_mean_func(self.freq_axis) / noise_array.mean(axis=0)

--- a/src/he6_cres_spec_sims/simulation_blocks/config.py
+++ b/src/he6_cres_spec_sims/simulation_blocks/config.py
@@ -1,5 +1,6 @@
 import yaml
 import pathlib
+import numpy as np
 from he6_cres_spec_sims.spec_tools.trap_field_profile import TrapFieldProfile
 
 class DotDict(dict):
@@ -100,6 +101,9 @@ class Config:
                     self.trackbuilder = DotDict(config_dict["TrackBuilder"])
                     self.downmixer = DotDict(config_dict["DMTrackBuilder"])
                     self.daq = DotDict(config_dict["Daq"])
+
+                print("RS: "+str(self.settings.rand_seed))
+                self.rng = np.random.default_rng(self.settings.rand_seed)
 
         except Exception as e:
             print("Config file failed to load.")

--- a/src/he6_cres_spec_sims/simulation_blocks/eventBuilder.py
+++ b/src/he6_cres_spec_sims/simulation_blocks/eventBuilder.py
@@ -62,7 +62,7 @@ class EventBuilder:
                 (
                     initial_position,
                     initial_direction,
-                ) = self.physics.generate_beta_position_direction(beta_num)
+                ) = self.physics.generate_beta_position_direction()
 
                 energy = self.physics.generate_beta_energy(beta_num)
 

--- a/src/he6_cres_spec_sims/simulation_blocks/physics.py
+++ b/src/he6_cres_spec_sims/simulation_blocks/physics.py
@@ -18,14 +18,12 @@ class Physics:
 
         return self.bs.energy_array[beta_num]
 
-    def generate_beta_position_direction(self, beta_num):
+    def generate_beta_position_direction(self):
 
         # Could maybe improve this by not generating a new one each time,
         # it could be vectorized the way the energy is...
 
-        position, direction = sc.random_beta_generator(
-            self.config.physics, self.config.settings.rand_seed + beta_num
-        )
+        position, direction = sc.random_beta_generator( self.config.physics, self.config.rng)
 
         return position, direction
     

--- a/src/he6_cres_spec_sims/simulation_blocks/segmentBuilder.py
+++ b/src/he6_cres_spec_sims/simulation_blocks/segmentBuilder.py
@@ -68,19 +68,15 @@ class SegmentBuilder:
 
                 # Physics happens. TODO: This could maybe be wrapped into a different method.
 
-                #first need to set seed for np.random
-                np.random.seed(self.config.settings.rand_seed)
-
                 # Jump Size: Sampled from normal dist.
                 mu = self.config.segmentbuilder.jump_size_eV
                 sigma = self.config.segmentbuilder.jump_std_eV
-                jump_size_eV = np.random.normal(mu, sigma)
+                jump_size_eV = self.config.rng.normal(mu, sigma)
 
                 # Delta Pitch Angle: Sampled from normal dist.
                 mu, sigma = 0, self.config.segmentbuilder.pitch_angle_costheta_std
-                rand_float = np.random.normal(
-                    mu, sigma
-                )  # Necessary to properly distribute angles on a sphere.
+                rand_float = self.config.rng.normal( mu, sigma)
+                # Necessary to properly distribute angles on a sphere.
                 delta_center_theta = (np.arccos(rand_float) - PI / 2) * RAD_TO_DEG
 
                 # Second, calculate new pitch angle and energy.
@@ -213,10 +209,6 @@ class SegmentBuilder:
     def segment_length(self):
         """TODO: DOCUMENT"""
         mu = self.config.segmentbuilder.mean_track_length
-
-        #first need to set seed for np.random
-        np.random.seed(self.config.settings.rand_seed)
-
-        segment_length = np.random.exponential(mu)
+        segment_length = self.config.rng.exponential(mu)
 
         return segment_length

--- a/src/he6_cres_spec_sims/simulation_blocks/trackBuilder.py
+++ b/src/he6_cres_spec_sims/simulation_blocks/trackBuilder.py
@@ -31,11 +31,8 @@ class TrackBuilder:
         # dealing with timing of the events.
         # for now just put all events in the window... need to think about this.
 
-        #first need to set seed for np.random
-        np.random.seed(self.config.settings.rand_seed)
-        
         window = self.config.daq.n_files*self.config.daq.spec_length
-        trapped_event_start_times = np.random.uniform(0, window, events_simulated)
+        trapped_event_start_times = self.config.rng.uniform(0, window, events_simulated)
 
         # iterate through the segment zeros and fill in start times.
 

--- a/src/he6_cres_spec_sims/spec_tools/beta_source/beta_source.py
+++ b/src/he6_cres_spec_sims/spec_tools/beta_source/beta_source.py
@@ -73,7 +73,7 @@ class BetaSource:
                     self.energy_array_len,
                     self.energy_acceptance_low,
                     self.energy_acceptance_high,
-                    self.config.settings.rand_seed,
+                    self.config.rng,
                 )
 
                 print("Fraction of total spectrum: {}\n ".format(self.fraction_of_spectrum))

--- a/src/he6_cres_spec_sims/spec_tools/beta_source/beta_spectrum.py
+++ b/src/he6_cres_spec_sims/spec_tools/beta_source/beta_spectrum.py
@@ -96,12 +96,10 @@ class BetaSpectrum:
         return self.dNdE_unnormed_SM(W) * (1 + (self.b / W))
 
 
-    def energy_samples(self, n, E_start, E_stop, rand_seed):
+    def energy_samples(self, n, E_start, E_stop, rng):
 
             """Produce n random samples from dNdE(E) between E_start and E_stop assuming constant spacing in Ws.
             Also return the fraction of the entire spectrum this accounts for."""
-
-            rng = np.random.default_rng(rand_seed)
 
             fraction_of_spectrum = None
 

--- a/src/he6_cres_spec_sims/spec_tools/beta_source/beta_spectrum_alej_OLD.py
+++ b/src/he6_cres_spec_sims/spec_tools/beta_source/beta_spectrum_alej_OLD.py
@@ -173,11 +173,9 @@ class BetaSpectrum:
         az8 = -3.0 / 8.0 * (ALPHA * Z) ** 8
         return 1.0 + az1 + az2 + az3 + az4 + az6 + az8 - 1.0 / 3.0 * (p(W) * r) ** 2
 
-    def energy_samples(self, n, E_start, E_stop, rand_seed):
+    def energy_samples(self, n, E_start, E_stop, rng):
         """Produce n random samples from dNdE(E) between E_start and E_stop.
         Also return the fraction of the entire spectrum this accounts for."""
-
-        rng = np.random.default_rng(rand_seed)
 
         fraction_of_spectrum = None
 

--- a/src/he6_cres_spec_sims/spec_tools/spec_calc/spec_calc.py
+++ b/src/he6_cres_spec_sims/spec_tools/spec_calc/spec_calc.py
@@ -24,8 +24,6 @@ import os
 
 import numpy as np
 
-# from numpy.random import uniform
-
 import scipy.integrate as integrate
 from scipy.fft import fft
 from scipy.optimize import fmin, fminbound
@@ -109,18 +107,13 @@ def power_from_slope(energy, slope, field):
     return power
 
 
-def random_beta_generator(parameter_dict, rand_seed):
+def random_beta_generator(parameter_dict, rng):
 
-    """TODO(byron): Think about if the phi_initial parameter has an
-    effect.
-
+    """
     Generates a random beta in the trap with pitch angle between
     min_theta and max_theta , and initial position (rho,0,z) between
     min_rho and max_rho and min_z and max_z.
     """
-    # Initialize rng. Mult by arbitrary int because seed may be used elsewhere.
-    rng = np.random.default_rng(rand_seed * 11)
-
     min_rho = parameter_dict["min_rho"]
     max_rho = parameter_dict["max_rho"]
 
@@ -133,7 +126,6 @@ def random_beta_generator(parameter_dict, rand_seed):
     # Uniform distribution in an annulus in cylindrical coordinates, found by inverse transform sampling
     rho_initial = np.sqrt(min_rho**2 + rng.uniform(0, 1) * (max_rho**2 - min_rho**2))
     phi_initial = 2 * PI * rng.uniform(0, 1) * RAD_TO_DEG
-    # phi_initial = 0
     z_initial = rng.uniform(min_z, max_z)
 
     u_min = (1 - np.cos(min_theta)) / 2


### PR DESCRIPTION
Removes all np.random calls. Everything goes through a single rng instance, which is called from everywhere via the config class

I was concerned that python passes arguments by value, not reference. This would be catastrophic, as moving around this rng would mean calls of the copy of the rng would not "progress" it, and you would keep getting the same numbers. This seems to be not the case

[rand_test.py.txt](https://github.com/Helium6CRES/he6-cres-spec-sims/files/15339889/rand_test.py.txt)

I get the same sequence of numbers despite the order of the last few lines. I do not get the same 1st number over and over


To pull from entropy from your OS (apparently random numbers, instead of a set seed, set the seed to None). I don't believe we handle defaults right now
